### PR TITLE
Correct debug instructions

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -212,7 +212,7 @@ run_method_single <- function(method, model, draws_list) {
                      model@name, draws_list$draws@index)
     code3 <- sprintf(".Random.seed <<- as.integer(c(%s))\n",
                      paste(cur_seed, collapse = ", "))
-    code4 <- sprintf(paste0("met@method(model = m, draw = d$%s)"), rid)
+    code4 <- sprintf(paste0("met@method(model = m, draw = d@draws$%s)"), rid)
     hint <- sprintf(paste0("The following code can be used to recreate the ",
                            "error, where 'met' is the method object (i.e. met@name ",
                            "== \"%s\") and 'sim' is your simulation object:\n\n",


### PR DESCRIPTION
Hi Jacob! Thanks for making modification that allows me to access the specific draw that's giving me grief. The instructions are incredibly helpful, but need to be modified slightly to help access the correct draw. This is a trivial change, but I thought it might help someone in future.

Need to reference the draws field of the draws object `d` in order to access the specific draw that created the error. E.g. `d$r1.1` does not access it correctly, but instead `d@draws$r1.1`